### PR TITLE
DEMOLISH doesn't forward exception if eval is used inthere

### DIFF
--- a/lib/Class/Std.pm
+++ b/lib/Class/Std.pm
@@ -517,6 +517,11 @@ sub DESTROY {
     my $id = ID($self);
     push @_, $id;
 
+    # if a DEMOLISH method uses eval without an exception $@ is cleared so
+    # local()ize the current exception (if any) so that it gets restored
+    # see https://rt.cpan.org/Public/Bug/Display.html?id=95834
+    local $@ = $@;
+
     for my $base_class (_hierarchy_of(ref $_[0])) {
         no strict 'refs';
         if (my $demolish_ref = *{$base_class.'::DEMOLISH'}{CODE}) {

--- a/t/demolish-eval.t
+++ b/t/demolish-eval.t
@@ -1,0 +1,31 @@
+use warnings;
+use strict;
+
+package Test ;
+use base qw( Exporter ) ;
+
+use Carp ;
+use Class::Std ;
+
+sub exec_proc {
+  croak 'Test exception' ;
+}	
+
+sub DEMOLISH {
+  eval { print "Demolish\n" }
+  # without eval the exception in exec_proc gets forwarded to the caller
+#  print "Demolish\n" ;
+} 
+
+package main;
+use English;
+use Test::More tests => 1;
+
+my $subref =sub  {
+  my $p_obj = Test->new( { } ) ;
+  $p_obj->exec_proc() ; 
+} ;
+
+eval { $subref->() ;} ;
+
+ok( $EVAL_ERROR, 'exception was not gobbled' );


### PR DESCRIPTION
local()ize $@ so that it can bubble up instead of getting reset if
a DEMOLISH callback uses eval

fixes https://rt.cpan.org/Public/Bug/Display.html?id=95834
