### PR TITLE
in ->can override let the real U::can() handle overload methods

### DIFF
--- a/lib/Class/Std.pm
+++ b/lib/Class/Std.pm
@@ -560,7 +560,15 @@ sub AUTOLOAD {
         my ($invocant, $method_name) = @_;
 
         if ( defined $invocant ) {
-            if (my $sub_ref = $real_can->(@_)) {
+            if ((my $sub_ref = $real_can->(@_))
+                || $method_name=~/^[()]/
+                # overload special methods all start with an open paren which
+                # we must avoid, or we risk infinite loops if Carp calls $obj->can("((")
+                # see: https://rt.perl.org/Ticket/Display.html?id=132902
+                # Note, we do a charclass with open AND close in it to avoid confusing syntax
+                # highlighters and editors -- it should be harmless, normal code shouldn't
+                # be creating methods with oddball names like this.
+            ) {
                 return $sub_ref;
             }
 


### PR DESCRIPTION
The current implementation of Class::Std->can() will infinite loop if Carp calls
can() to find out if a package uses overloads. It should let perls UNIVERSAL::can do the
work for these methods.

See https://rt.perl.org/Ticket/Display.html?id=132902