### PR TITLE
Tweak the UNIVERSAL::can override to allow SUPER::foo to work

### DIFF
--- a/lib/Class/Std.pm
+++ b/lib/Class/Std.pm
@@ -576,7 +576,7 @@ sub AUTOLOAD {
             }
         }
 
-        return;
+        goto &$real_can;
     };
 }
 


### PR DESCRIPTION
SUPER:: is always sort-of broken:

    * $obj->SUPER::foo will never actually use $obj for the method
      resolution -- it will use the *package in which the code was
      compiled in*.
    * $obj->can('SUPER::foo'), similarly, will use the "current"
      place in the callstack to find the next one.

The problem here is that Class::Std overrides UNIVERSAL::can,
so when it calls $original_can->($class, $method) and $method
is SUPER::foo, the SUPER code will look at the 'current' place
in the callstack.. which is the UNIVERSAL::can override in
Class::Std.

Whoops.

In particular, this was breaking AnyEvent, which uses this
lovely construct:

    goto &{ UNIVERSAL::can AnyEvent => "SUPER::$name" }

Previously, SUPER::$name broke if Class::Std was loaded.