### PR TITLE
only install can method in Class::Std classes

### DIFF
--- a/lib/Class/Std.pm
+++ b/lib/Class/Std.pm
@@ -576,7 +576,7 @@ sub AUTOLOAD {
             }
         }
 
-        return;
+        return undef;
     };
 }
 

--- a/t/automethod.t
+++ b/t/automethod.t
@@ -1,3 +1,6 @@
+package Empty;
+use Class::Std;
+
 package Common;
 use Class::Std;
 {
@@ -36,6 +39,9 @@ package Qux;
 
 package main;
 use Test::More 'no_plan';
+
+my @return = Empty->can('baz');
+is_deeply( \@return, [undef],                => 'can always returns a single result' );
 
 my $meth_ref;
 

--- a/t/automethod.t
+++ b/t/automethod.t
@@ -36,6 +36,13 @@ use base qw( Bar );
 
 package Qux;
 
+package Guff;
+{
+    sub AUTOMETHOD {
+        return sub { return 'Common::foo()' };
+        return;
+    }
+}
 
 package main;
 use Test::More 'no_plan';
@@ -93,4 +100,7 @@ ok( !$meth_ref                               => 'Qux no can foo()'     );
 eval { Qux->foo() };
 ok( $@                                       => 'No Qux foo()'         );
 
-
+$meth_ref = Guff->can('foo');
+ok( !$meth_ref                               => 'Guff no can foo()'    );
+eval { Guff->foo() };
+ok( $@                                       => 'No Guff foo()'        );


### PR DESCRIPTION
A can method needs to be installed to implement part of the behavior of AUTOMETHOD. This should only have an impact on Class::Std classes, as it is tied to the AUTOLOAD method that is also installed.

Modifying UNIVERSAL::can has an impact on the entire process. It slows it down, as well as causing any bugs to impact the entire process. And the implementation of the can wrapper does have a bug regarding SUPER:: methods.

Rather than modifying UNIVERSAL::can, just install a can method in Class::Std classes. This limits the impact of any bugs or slowdowns. It also ensures that the AUTOMETHOD feature is properly limited to Class::Std classes.